### PR TITLE
Update class.jetpack-admin.php

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -93,7 +93,7 @@ class Jetpack_Admin {
 				} else {
 					do_action( 'jetpack_module_more_info_' . $module );
 				}
-				$module_array['long_description']  = ob_get_clean();
+				$module_array['long_description'] = apply_filters( 'jetpack_long_module_description', ob_get_clean(), $module );
 
 				$module_array['configurable'] = false;
 				if ( current_user_can( 'manage_options' ) && apply_filters( 'jetpack_module_configurable_' . $module, false ) ) {


### PR DESCRIPTION
As per https://wordpress.org/support/topic/hook-after-module-infophp-is-loaded?replies=9#post-6772580...

Some of the modules stop other plugins from working, for example; photon doesn't work with fancybox. I'd like to update the long description to let my clients know about conflicts in each of the modules.

This would allow developers to add a filter such as:

function custom_jetpack_more_info($module_description, $module_name) {
    if($module_name == 'photon') $module_description .= "Photon doesn't play nice with Fancybox";
    return $module_description;
}
add_filter( 'jetpack_long_module_description', 'custom_jetpack_more_info', 10, 2 );
